### PR TITLE
Correct command in AWS config file error message

### DIFF
--- a/lib/aws_mfa.rb
+++ b/lib/aws_mfa.rb
@@ -23,7 +23,7 @@ class AwsMfa
     end
 
     unless File.readable?(aws_config_file)
-      raise Errors::ConfigurationNotFound, 'Aws configuration not found. You must run `aws cli configure`'
+      raise Errors::ConfigurationNotFound, 'Aws configuration not found. You must run `aws configure`'
     end
 
     aws_config_dir


### PR DESCRIPTION
The error message when the user doesn't have an AWS config file has a stray "cli" in the command that needs to be run to set it up.

Tests:
> 10 examples, 0 failures
> Randomized with seed 37151