### PR TITLE
Clean up the ARN before using it.

### DIFF
--- a/lib/aws_mfa.rb
+++ b/lib/aws_mfa.rb
@@ -51,6 +51,7 @@ class AwsMfa
       write_arn_to_file(arn_file, arn)
     end
 
+    arn.strip! if arn.respond_to?(:strip!)
     arn
   end
 


### PR DESCRIPTION
aws-mfa does not work on my Ruby 2.1.5 without this fix. Might be useful for others, and should not change the behavior in any meaningful way.