### PR TITLE
Handle incorrect MFA token code

### DIFF
--- a/bin/aws-mfa
+++ b/bin/aws-mfa
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+$LOAD_PATH.unshift File.expand_path(File.join(File.dirname(__FILE__), '../lib'))
+
 require 'aws_mfa'
 
 begin

--- a/lib/aws_mfa.rb
+++ b/lib/aws_mfa.rb
@@ -74,7 +74,15 @@ class AwsMfa
   end
 
   def mfa_devices(profile='default')
-    @mfa_devices ||= JSON.parse(`aws --profile #{profile} --output json iam list-mfa-devices`).fetch('MFADevices')
+    @mfa_devices ||= begin
+      list_mfa_devices_command = "aws --profile #{profile} --output json iam list-mfa-devices"
+      result = AwsMfa::ShellCommand.new(list_mfa_devices_command).call
+      if result.succeeded?
+        JSON.parse(result.output).fetch('MFADevices')
+      else
+        raise Errors::Error, 'There was a problem fetching MFA devices from AWS'
+      end
+    end
   end
 
   def write_arn_to_file(arn_file, arn)

--- a/lib/aws_mfa.rb
+++ b/lib/aws_mfa.rb
@@ -1,5 +1,7 @@
 require 'json'
 require 'aws_mfa/errors'
+require 'aws_mfa/shell_command'
+require 'aws_mfa/shell_command_result'
 
 class AwsMfa
   attr_reader :aws_config_dir

--- a/lib/aws_mfa.rb
+++ b/lib/aws_mfa.rb
@@ -106,7 +106,13 @@ class AwsMfa
   def load_credentials_from_aws(arn, profile='default')
     code = request_code_from_user
     unset_environment
-    `aws --profile #{profile} --output json sts get-session-token --serial-number #{arn} --token-code #{code}`
+    credentials_command = "aws --profile #{profile} --output json sts get-session-token --serial-number #{arn} --token-code #{code}"
+    result = AwsMfa::ShellCommand.new(credentials_command).call
+    if result.succeeded?
+      result.output
+    else
+      raise Errors::InvalidCode, 'There was a problem validating the MFA code with AWS'
+    end
   end
 
   def write_credentials_to_file(credentials_file, credentials)

--- a/lib/aws_mfa/shell_command.rb
+++ b/lib/aws_mfa/shell_command.rb
@@ -1,0 +1,14 @@
+class AwsMfa
+  class ShellCommand
+    attr_reader :command
+
+    def initialize(command)
+      @command = command
+    end
+
+    def call
+      output = `#{command}`
+      ShellCommandResult.new(output, $?)
+    end
+  end
+end

--- a/lib/aws_mfa/shell_command_result.rb
+++ b/lib/aws_mfa/shell_command_result.rb
@@ -1,0 +1,18 @@
+class AwsMfa
+  class ShellCommandResult
+    attr_reader :output
+
+    def initialize(command_output, process_status)
+      @output = command_output
+      @process_status = process_status
+    end
+
+    def succeeded?
+      process_status.success?
+    end
+
+    private
+
+    attr_reader :process_status
+  end
+end

--- a/spec/awsmfa_spec.rb
+++ b/spec/awsmfa_spec.rb
@@ -62,6 +62,16 @@ RSpec.describe 'AwsMfa' do
       }])
       expect(subject.load_arn).to eq 'foo'
     end
+
+    it 'raises an error when there is a problem with aws' do
+      command = double(call: double(succeeded?: false))
+      allow(AwsMfa::ShellCommand).to receive(:new).and_return(command)
+
+      expect { subject.load_arn }.to raise_error(
+        AwsMfa::Errors::Error,
+        'There was a problem fetching MFA devices from AWS'
+      )
+    end
   end
 
   describe '#load_arn_profile' do

--- a/spec/awsmfa_spec.rb
+++ b/spec/awsmfa_spec.rb
@@ -110,6 +110,16 @@ RSpec.describe 'AwsMfa' do
       allow(subject).to receive(:load_credentials_from_aws).and_return('{"Credentials":"foo"}')
       expect(subject.load_credentials('arn')).to eq 'foo'
     end
+
+    it 'raises an error when aws returns an error' do
+      allow(subject).to receive(:request_code_from_user).and_return('867530')
+      command = double(call: double(succeeded?: false))
+      allow(AwsMfa::ShellCommand).to receive(:new).and_return(command)
+      expect { subject.load_credentials('arn') }.to raise_error(
+        AwsMfa::Errors::InvalidCode,
+        'There was a problem validating the MFA code with AWS'
+      )
+    end
   end
 
   describe '#load_credentials_profile' do

--- a/spec/shell_command_result_spec.rb
+++ b/spec/shell_command_result_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.describe 'AwsMfa::ShellCommandResult' do
+  context 'successful command' do
+    subject { AwsMfa::ShellCommandResult.new('hello world', process_status) }
+    let(:process_status) { double(success?: true)  }
+
+    it 'returns the command output' do
+      expect(subject.output).to eql('hello world')
+    end
+
+    it 'returns that the command succeeded' do
+      expect(subject.succeeded?).to eql(true)
+    end
+  end
+
+  context 'unsuccessful command' do
+    subject { AwsMfa::ShellCommandResult.new('hello world', process_status) }
+    let(:process_status) { double(success?: false)  }
+
+    it 'returns the command output' do
+      expect(subject.output).to eql('hello world')
+    end
+
+    it 'returns that the command failed' do
+      expect(subject.succeeded?).to eql(false)
+    end
+  end
+end

--- a/spec/shell_command_spec.rb
+++ b/spec/shell_command_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+RSpec.describe 'AWS::ShellCommand' do
+  subject { AwsMfa::ShellCommand.new('ls -1') }
+
+  describe '#new' do
+    it 'returns the command' do
+      expect(subject.command).to eq('ls -1')
+    end
+  end
+
+  describe '#call' do
+    it 'runs the command' do
+      allow(AwsMfa::ShellCommandResult).to receive(:new)
+      expect(subject).to receive(:`).with('ls -1')
+      subject.call
+    end
+
+    it 'returns the output' do
+      output = "Gemfile\nGemfile.lock\nLICENSE\nREADME.md"
+      allow(subject).to receive(:`).with('ls -1').and_return(output)
+
+      # Note: $? is a special read-only variable that is set by ruby after the
+      # ` method is invoked. $? will be nil in this case because the ` method
+      # is being stubbed for this test. If AwfMfa::ShellCommandResult is being
+      # called with something besides nil as the second argument, there is
+      # probably an unexpected invocation of ` somewhere else in the test(s)
+      # preceeding this one that is setting $?.
+      expect(AwsMfa::ShellCommandResult).to receive(:new).with(output, nil)
+
+      subject.call
+    end
+  end
+end


### PR DESCRIPTION
I frequently enter the wrong MFA code or typo it. Previously, this corrupted the `~/.aws/mfa_credentials` file and caused future calls to `aws-mfa` to fail. This PR adds a check on the response from AWS before storing results in the `~/.aws/mfa_credentials`.

I added an `AwsMfa::ShellCommand` abstraction for shell commands so that the success/fail logic was easier to read (and test). I also used the new abstraction on the other shell command when fetching MFA devices.

You can test the new error handling locally now by running the following (assuming your current MFA code is not `222222` :smile:):

```
$> rm ~/.aws/mfa_credentials
$> bin/aws-mfa
Enter the 6-digit code from your MFA device:
222222

A client error (AccessDenied) occurred when calling the GetSessionToken operation: MultiFactorAuthentication failed with invalid MFA one time pass code.
There was a problem validating the MFA code with AWS
```