### PR TITLE
Update Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aws-mfa (0.3.0)
+    aws-mfa (0.3.1)
 
 GEM
   remote: https://rubygems.org/
@@ -43,4 +43,4 @@ DEPENDENCIES
   simplecov (~> 0.9)
 
 BUNDLED WITH
-   1.11.2
+   1.12.5


### PR DESCRIPTION
I missed this in the previous commit and release. It's causing the builds to
fail since the Gemfile.lock specifies 0.3.0, but the gemspec (which is
referenced by the Gemfile) specifies 0.3.1.