### PR TITLE
Output messages to STDERR

### DIFF
--- a/lib/aws_mfa.rb
+++ b/lib/aws_mfa.rb
@@ -65,7 +65,7 @@ class AwsMfa
   end
 
   def load_arn_from_aws(profile='default')
-    puts 'Fetching MFA devices for your account...'
+    STDERR.puts 'Fetching MFA devices for your account...'
     if mfa_devices(profile).any?
       mfa_devices(profile).first.fetch('SerialNumber')
     else
@@ -87,7 +87,7 @@ class AwsMfa
 
   def write_arn_to_file(arn_file, arn)
     File.open(arn_file, 'w') { |f| f.print arn }
-    puts "Using MFA device #{arn}. To change this in the future edit #{arn_file}."
+    STDERR.puts "Using MFA device #{arn}. To change this in the future edit #{arn_file}."
   end
 
   def load_credentials(arn, profile='default')
@@ -128,7 +128,7 @@ class AwsMfa
   end
 
   def request_code_from_user
-    puts 'Enter the 6-digit code from your MFA device:'
+    STDERR.puts 'Enter the 6-digit code from your MFA device:'
     code = $stdin.gets.chomp
     raise Errors::InvalidCode, 'That is an invalid MFA code' unless code =~ /^\d{6}$/
     code


### PR DESCRIPTION
This way user-oriented messages don't interfere with the `export` output when using the `eval $(aws-mfa)` form (e.g. prompting for the MFA code still works).