### PR TITLE
Fixed newline at the end of the mfa arn file

### DIFF
--- a/lib/aws_mfa.rb
+++ b/lib/aws_mfa.rb
@@ -61,7 +61,7 @@ class AwsMfa
   end
 
   def load_arn_from_file(arn_file)
-    File.read(arn_file)
+    File.read(arn_file).chomp
   end
 
   def load_arn_from_aws(profile='default')


### PR DESCRIPTION
If you put the mfa arn in the file `~/.aws/mfa_device` by yourself, you can end up with a newline at the end of the file. In which case chomp it off!